### PR TITLE
Adds minimal README.md to the repository with build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# Eclipse Tooling for JavaFX
+
+## How to build
+
+To build this tooling, switch to the efxclipse-eclipse/releng/org.eclipse.fx.ide.releng folder and run:
+
+```
+mvn clean verify
+```
+


### PR DESCRIPTION
Missing instructions for building the tooling makes it harder for
contributors to find out how to build the tooling
As the performance and reliability of Eclipse.org is very bad for
nightly update sites, local builds are frequently necessary.

Change-Id: I061bd4b5fe0d526a7d38f26257237b743585c5e0
Signed-off-by: Lars Vogel <Lars.Vogel@vogella.com>