### PR TITLE
Enable build of the repo from the root of the directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,10 @@
 
 ## How to build
 
-To build this tooling, switch to the efxclipse-eclipse/releng/org.eclipse.fx.ide.releng folder and run:
+To build this tooling run the following command from the root of the repository.
 
 ```
 mvn clean verify
 ```
 
+The master pom is only a pointer to the `efxclipse-eclipse/releng/pom.xml` which contains the full build configuration.

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+	xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<modelVersion>4.0.0</modelVersion>
+	<name>Placeholder for building from main directory</name>
+
+	<prerequisites>
+		<maven>3.0</maven>
+	</prerequisites>
+
+	<groupId>org.eclipse.fx.ide</groupId>
+	<artifactId>build-placeholder</artifactId>
+	<version>3.5.0-SNAPSHOT</version>
+	<packaging>pom</packaging>
+	<modules>
+		<module>./releng/org.eclipse.fx.ide.releng</module>
+    </modules>
+</project>


### PR DESCRIPTION
Maven users except that they can build the repository from the root of
the repository. This change adds a placeholder pom which points to the
efxclipse-eclipse/releng/org.eclipse.fx.ide.releng/pom.xml file.

Also updates the README.md with this information.